### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -248,6 +248,7 @@ a {
   width: 37vh;
   padding: 1vw;
   background-color: #FFF;
+  list-style: none;
 }
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except:[:index]
   def index
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,25 +126,26 @@
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% if @items[0] != nil %>
+      <% @items.each do |item|%>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <%# 商品が売れていればsold outを表示しましょう(商品購入機能実装後) %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <%# //商品が売れていればsold outを表示しましょう(商品購入機能実装後) %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= "#{item.name}" %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= "#{item.price}" %>円<br><%= "#{item.postagetype.name}" %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +154,11 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
+      <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,8 +176,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -142,10 +142,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "#{item.name}" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "#{item.price}" %>円<br><%= "#{item.postagetype.name}" %></span>
+            <span><%= item.price %>円<br><%= item.postagetype.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>


### PR DESCRIPTION
### What
最終課題フリマアプリタスク「商品一覧表示機能」を実装したのでレビューをお願いします。
登録ユーザが出品した商品をトップ画面へ表示する。
商品一覧はユーザ登録の有無に関わらず閲覧可能にする。

### Why
DBに保存された情報の表示のため。

**稼働確認エビデンス**
①商品出品前後の稼働確認
商品出品前：　[https://gyazo.com/2ecda369056d9c8bdd470b8ff856db58](https://gyazo.com/2ecda369056d9c8bdd470b8ff856db58)
商品出品後：　[https://gyazo.com/74041ad84506f874981a45a6ec27dc6e](https://gyazo.com/74041ad84506f874981a45a6ec27dc6e)

②未登録ユーザの閲覧状況：　[https://gyazo.com/444e241f8fa68885ce8f7009e8116f00
](https://gyazo.com/444e241f8fa68885ce8f7009e8116f00)
